### PR TITLE
[ADD] 전체게시글  CRUD

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,12 +6,14 @@ const morgan =require('morgan');
 const appDataSource = require('./models/dataSource');
 const { globalErrorHandler } = require('./utils/error');
 const route = require('./routes');
+const cookieParser = require('cookie-parser');
 
 const app = express();
 
 app.use(cors());
 app.use(morgan('dev'));
 app.use(express.json());
+app.use(cookieParser());
 app.use(route);
 app.use(globalErrorHandler);
 

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -1,0 +1,77 @@
+const postService = require('../services/postService');
+const { catchAsync } = require('../utils/error');
+const { getPost } = require('../getPost');
+
+const getPostByPostName = async ( req, res ) => {
+    
+    const { type, offset, limit } = req.query;
+
+    if( !type || !offset || !limit ){
+        const error = new Error('KEY ERROR');
+        error.statusCode = 400;
+        throw error;
+    }
+        
+        const posts = await postService.getPostByPostName(
+            getPost(type),
+            +offset,
+            +limit
+        );
+
+        res.status(200).json({ data : posts });
+}
+
+const registerPostByAdminId = catchAsync( async (req, res) => {
+
+    const { type } = req.query;
+    const { adminId, title, content, branchId } = req.body;
+    let image = ''
+    
+    if(req.file)image = req.file.location;
+
+    if ( !adminId || !title || !content || !branchId ) {
+        const error = new Error('KEY ERROR');
+        error.statusCode = 400;
+        throw error;
+    }
+
+    await postService.registerPostByAdminId( getPost(type), title, content, +adminId, +branchId, image );
+
+    res.status(201).json({ message : 'SUCCESS' });
+});
+
+const updatePost = catchAsync( async (req, res) => {
+    const { postId } = req.params;
+    const { type } = req.query;
+    const { title, content } = req.body;
+
+    await postService.updatePost( +postId, getPost(type), title, content );
+    
+    res.status(200).json({ mesage : 'update complete '});
+});
+
+const deletePost = catchAsync( async (req, res) => {
+    const { type } = req.query;
+    const { postId } = req.params;
+    
+    await postService.deletePost( getPost(type), +postId );
+    
+    res.status(200).json({ message : 'delete complete' });
+});
+
+const getPostByPostId = catchAsync( async (req, res) => {
+    const { postId } = req.params;
+    const { type } = req.query;
+    
+    const detail = await postService.getPostByPostId( getPost(type), postId);
+
+   return res.status(200).json({ data : detail });
+});
+
+module.exports = { 
+    registerPostByAdminId,
+    updatePost,
+    deletePost,
+    getPostByPostId,
+    getPostByPostName
+}

--- a/getPost.js
+++ b/getPost.js
@@ -1,0 +1,9 @@
+const getPost = (type) =>{
+    const postSet = {
+      notice: 'notices',
+      news: 'news'
+    }
+    return type ? postSet[type] : '' ;
+  }
+
+module.exports = { getPost }

--- a/models/postDao.js
+++ b/models/postDao.js
@@ -1,0 +1,127 @@
+const appDataSource = require('./dataSource');
+
+const getPostByPostName = async ( type, offset, limit ) => {
+    let newsImageUrl = '';
+
+    if(type == 'news') newsImageUrl = 'image_url,'; 
+
+    try {  
+        return await appDataSource.query(`
+            SELECT
+                title,
+                content,
+                view_count,
+                ${newsImageUrl}
+                created_at
+            FROM ${type} 
+            LIMIT ?,?
+        `, [offset, limit]
+        )
+
+    }
+    catch (err) {
+        const error = new Error(err.message);
+        error.statusCode = 500;
+        throw error;
+    }
+
+}
+
+const registerPostByAdminId = async ( type, title, content, adminId, branchId, image ) => {
+    
+    let newsImageUrl = '';
+    let values = '';
+    let valueArray = [ title, content, adminId, branchId ]
+
+    if(image){ 
+        newsImageUrl = 'image_url,';
+        values = '?,'
+        valueArray = [ title, content, image, adminId, branchId ];
+    }
+
+    try {
+        await appDataSource.query(`
+            INSERT INTO ${type}(
+                title,
+                content,
+                ${newsImageUrl}
+                admin_id,
+                branch_id
+            )VALUES ( ?, ?,${values} ?, ? )`,
+            valueArray );
+    }
+    catch (err) {
+        const error = new Error(err.message);
+        error.statusCode = 500;
+        throw error;
+    }
+    
+}
+
+const deletePost = async ( type, postId ) => {
+    try{
+    await appDataSource.query(
+        `DELETE FROM 
+            ${type} 
+        WHERE ${type}.id = ?`,[ postId ]
+    )
+    }
+    catch (err) {
+        const error = new Error(err.message);
+        error.statusCode = 500;
+        throw error;
+    }
+
+}
+
+const updatePost = async ( postId, type, title, content ) => {
+    
+    try{
+    await appDataSource.query(`
+        UPDATE ${type}
+            SET 
+                title = ?,
+                content = ?
+            WHERE id = ?
+    ` , [ title, content, postId ])
+    }
+    catch (err) {
+        const error = new Error(err.message);
+        error.statusCode = 500;
+        throw error;
+    }
+}
+
+const getPostByPostId = async ( type, postId ) => {
+    try {
+        const detail = appDataSource.query(`
+            SELECT
+                ${type}.id,
+                title,
+                content,
+                view_count,
+                u.name
+            FROM ${type}
+            INNER JOIN admins a ON a.id = ${type}.admin_id
+            INNER JOIN users u ON u.id = a.user_id
+            WHERE ${type}.id = ? 
+        `,[ postId ])
+
+        return detail;
+    }
+    catch (err) {
+        const error = new Error(err.message);
+        error.statusCode = 500;
+        throw error;
+    }
+}
+
+
+
+module.exports = {
+    registerPostByAdminId,
+    deletePost,
+    updatePost,
+    getPostByPostId,
+    getPostByPostName
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "aws-sdk": "^2.1249.0",
         "axios": "^0.21.4",
         "bcrypt": "^5.1.0",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dbmate": "^1.0.3",
         "dotenv": "^16.0.3",
@@ -20,6 +21,7 @@
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^2.10.0",
         "mysql2": "^2.3.3",
+        "request-ip": "^3.3.0",
         "typeorm": "^0.3.10"
       },
       "devDependencies": {
@@ -599,6 +601,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1992,6 +2014,11 @@
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3219,6 +3246,22 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
@@ -4269,6 +4312,11 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
+    "request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "aws-sdk": "^2.1249.0",
     "axios": "^0.21.4",
     "bcrypt": "^5.1.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dbmate": "^1.0.3",
     "dotenv": "^16.0.3",
@@ -30,6 +31,7 @@
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^2.10.0",
     "mysql2": "^2.3.3",
+    "request-ip": "^3.3.0",
     "typeorm": "^0.3.10"
   },
   "devDependencies": {
@@ -37,5 +39,3 @@
     "nodemon": "^2.0.20"
   }
 }
-
-

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,3 +1,7 @@
 const router = require('express').Router();
 
+const postRouter = require('./postRouter');
+
+router.use('/post', postRouter);
+
 module.exports = router;

--- a/routes/postRouter.js
+++ b/routes/postRouter.js
@@ -1,0 +1,12 @@
+const postRouter = require('express').Router();
+const { viewCount } = require('../utils/viewCount');
+const { imageUploader } = require('../utils/imageUploader');
+const postController = require('../controllers/postController');
+
+postRouter.get('', postController.getPostByPostName);
+postRouter.post('', imageUploader.single('image'), postController.registerPostByAdminId);
+postRouter.patch('/:postId',postController.updatePost);
+postRouter.delete('/:postId', postController.deletePost);
+postRouter.get('/:postId', viewCount, postController.getPostByPostId);
+
+module.exports = postRouter;

--- a/services/postService.js
+++ b/services/postService.js
@@ -1,0 +1,42 @@
+const postDao = require('../models/postDao');
+
+
+const getPostByPostName = async ( type, offset, limit ) => {
+
+    return await postDao.getPostByPostName( type, offset, limit );
+}
+
+const registerPostByAdminId = async ( type, title, content, adminId, branchId, image ) => {
+
+    return await postDao.registerPostByAdminId( type, title, content, adminId, branchId, image );
+}
+
+const updatePost = async ( postId, type, title, content ) => {
+    const updatePost = postDao.updatePost( postId, type, title, content );
+    
+    return updatePost
+}
+
+const deletePost = async ( type, postId ) => {
+    const deletePostId = postDao.deletePost( type, postId );
+
+    return deletePostId;
+}
+
+const getPostByPostId = async ( type, postId ) => {
+    const getPostDetail = postDao.getPostByPostId( type, postId );
+
+    return getPostDetail;
+}
+
+
+
+
+
+module.exports = { 
+    registerPostByAdminId,
+    updatePost,
+    deletePost,
+    getPostByPostId,
+    getPostByPostName
+}

--- a/utils/imageUploader.js
+++ b/utils/imageUploader.js
@@ -1,0 +1,33 @@
+const AWS = require('aws-sdk');
+const multer = require('multer');
+const multerS3 = require('multer-s3');
+const path = require('path');
+
+AWS.config.update({
+  region: process.env.AWS_S3_REGION,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+});
+
+const s3 = new AWS.S3()
+
+const allowedExtensions = ['.png', '.jpg', '.jpeg', '.bmp']
+
+const imageUploader = multer({
+  storage: multerS3({
+    s3: s3,
+    bucket: 'star-picker',
+    contentType: multerS3.AUTO_CONTENT_TYPE,
+    key: (req, file, callback) => {
+      const uploadDirectory = req.query.directory ?? ''
+      const extension = path.extname(file.originalname)
+      if (!allowedExtensions.includes(extension)) {
+        return callback(new Error('wrong extension'))
+      }
+      callback(null, `${uploadDirectory}/${Date.now()}_${file.originalname}`)
+    },
+    acl: 'public-read-write'
+  }),
+})
+
+module.exports = { imageUploader }

--- a/utils/viewCount.js
+++ b/utils/viewCount.js
@@ -1,0 +1,45 @@
+const appDataSource = require('../models/dataSource');
+const { getPost } = require('../getPost')
+
+const viewCount = async ( req, res, next ) => {
+    const queryRunner = appDataSource.createQueryRunner();
+    const { type } = req.query;
+    const { postId } = req.params;
+
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    
+    try {
+
+        function getUserIP (req) {
+            const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
+            
+            return ip;
+        }
+        if ( !req.cookies[postId] ) {
+            res.cookie(postId, getUserIP(req), {
+                maxAge : 60000
+            })
+        
+            await queryRunner.query(`
+                UPDATE ${getPost(type)} SET
+                    view_count = view_count + 1
+                WHERE id = ?
+            `, [ postId ]);
+        }
+        
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return next();
+    } 
+    catch (err) {
+        await queryRunner.rollbackTransaction();
+        await queryRunner.release();
+
+        return next();
+    }
+     
+}
+
+module.exports = { viewCount }


### PR DESCRIPTION
-확장성과 유지보수를 고려하여 CRUD작업을 할 때에 게시글마다 앤드포인트를 따로 만들지 않고 method별로 query parameter(type)를 이용한 게시글 구분 구현

ex) 127.0.0.1:3000/post?type=notice  ( notice에 대한 crud 접근 가능 )

-게시글 상세조회를 할 시 Transaction을 적용시켜 해당 유저에게 해당 게시글에 대한 쿠키를 부여하여 조회수 중복 증가를 방지(viewCount 미들웨어)하고, 해당 게시글의 조회수 1 증가 구현

-news의 경우 사진 등록이 가능하므로 POST method 사용시 AWS S3와 연동하여 star-picker bucket에 사진이 form-data로 저장되고 응답할 수 있게 구현