### PR TITLE
[ADD] signup-signin

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,3 +9,14 @@ TYPEORM_PASSWORD=password
 TYPEORM_DATABASE=database_name
 TYPEORM_PORT=portnumber
 TYPEORM_LOGGING=boolean
+
+SENS_ACCESSKEY=naver-SENS-accesskey
+SENS_SECRETKEY=naver-SENS-secretkey
+SENS_SERVICEID=naver-SENS-serviceid
+
+KAKAO_REST_API_KEY=kakao-rest-api-key
+KAKAO_REDIRECT_URI=kakao-redirect-uri
+
+ALGORITHM=jwt-algorithm
+JWT_SECRET=jwt-secret-key
+JWT_EXPIRES_IN=jwt-expires-in

--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
+# schema.sql
+db/schema.sql
+
 # End of https://www.toptal.com/developers/gitignore/api/macos,node,dotenv,windows,linux

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,0 +1,392 @@
+const userService = require('../services/userService');
+const { catchAsync } = require('../utils/error');
+
+const sendVerificationSMS = catchAsync(async(req, res) => {
+    let { userName, userPhoneNumber, userEmail } = req.body
+
+    if(!userName||!userPhoneNumber||!userEmail) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400;
+
+        throw error
+    }
+
+    userName = userName.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+    userEmail = userEmail.toString();
+
+    const randomFourDigit = String(Math.floor(Math.random()*(10000-1000)) + 1000);
+
+    let SMS = await userService.checkUserByPhoneNEmail(userName, userPhoneNumber, randomFourDigit, userEmail);
+
+    if(SMS.statusCode === '202') {
+        SMS = '인증번호를 문자로 발송했습니다. 3분 내 인증을 완료해주세요'
+    };
+
+    res.status(200).json({'SMS':SMS});
+});
+
+const contrastVerificationCode = catchAsync(async(req, res) => {
+    let { userPhoneNumber, userKeyInCode } = req.body;
+
+    if(!userPhoneNumber||!userKeyInCode) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400;
+
+        throw error
+    }
+
+    userPhoneNumber = userPhoneNumber.toString();
+    userKeyInCode = userKeyInCode.toString();
+    
+    const verification =  await userService.contrastVerificationCode(userPhoneNumber, userKeyInCode);
+    res.status(200).json({ 'verification': verification })
+});
+
+const deleteUser = catchAsync(async(req, res) => {
+    let { userPhoneNumber } = req.body;
+
+    if(userPhoneNumber===undefined) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400;
+
+        throw error
+    };
+
+    userPhoneNumber = userPhoneNumber.toString();
+    
+    let result = await userService.deleteUser(userPhoneNumber);
+
+    if (result['affectedRows']===1) {
+        
+        result = `${userPhoneNumber}은 인증에 실패하였거나 시간초과로 삭제되었습니다. 재전송해주세요`
+    }
+    res.status(200).json({ 'message':result });
+});
+
+const clientSignup = catchAsync(async(req,res) => {
+
+    let { companyName, companyRegistrationNumber, companyEmail, userName, userEmail, userPhoneNumber } = req.body;
+    const { companyPassword } = req.body;
+
+    if(!companyName||!companyRegistrationNumber||!companyEmail||!companyPassword||!userName||!userEmail||!userPhoneNumber) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400;
+
+        throw error
+    }
+
+    companyName = companyName.toString().trim();
+    companyRegistrationNumber = +companyRegistrationNumber;
+    companyEmail = companyEmail.toString();
+    userName = userName.toString();
+    userEmail = userEmail.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+
+    let result = await userService.clientSignup(companyName, companyRegistrationNumber, companyEmail, companyPassword, userName, userEmail, userPhoneNumber);
+
+    if (result['affectedRows']===1) result = `환영합니다! 회원가입에 성공했습니다`;
+
+    res.status(201).json({ 'message' : result });
+});
+
+const clientSignin = catchAsync(async(req, res) => {
+    
+    let { companyEmail } = req.body;
+    const { companyPassword } = req.body;
+
+    if (!companyEmail||!companyPassword) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400;
+
+        throw error
+    }
+
+    companyEmail = companyEmail.toString();
+
+    const jwtAccessToken = await userService.clientSignin(companyEmail, companyPassword);
+    res.status(200).json({ 'accessToken':jwtAccessToken, 'message':'로그인 되었습니다'});
+});
+
+// -- UP -- 회원가입/로그인: client/user 회원가입 구현 -- UP --
+// --------------------------------------
+
+const branchSignup = catchAsync(async(req, res) => {
+
+    let { branchName, branchAddress, branchEmail, userName, userEmail, userPhoneNumber } = req.body;
+    const { branchPassword } = req.body;
+
+    if (!branchName||!branchAddress||!branchEmail||!branchPassword||!userName||!userEmail||!userPhoneNumber) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400
+
+        throw error
+    }
+
+    branchName = branchName.toString().trim();
+    branchAddress = branchAddress.toString();
+    branchEmail = branchEmail.toString();
+    userName = userName.toString();
+    userEmail = userEmail.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+
+    let result = await userService.branchSignup(branchName, branchAddress, branchEmail, branchPassword, userName, userEmail, userPhoneNumber);
+
+    if(typeof(result) === 'number') {
+        result = `환영합니다! 별따러가자 ${branchName} 및 관리자 생성을 성공했습니다!`
+    };
+    
+    res.status(201).json({ 'message' : result });
+});
+
+const adminSignin = catchAsync(async(req, res) => {
+
+    let { branchEmail } = req.body;
+    const { branchPassword } = req.body;
+
+    if (!branchEmail||!branchPassword) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 400
+
+        throw error
+    }
+
+    branchEmail = branchEmail.toString();
+
+    const accessToken = await userService.adminSignin(branchEmail, branchPassword);
+
+    const branch = await userService.getAdminByBranchEmail(branchEmail);
+    const branchName = branch['branchName'];
+    const adminId = branch['adminId'];
+
+    res.status(200).json({ 'accessToken' : accessToken, 'adminId' : adminId, 'message' : `별따러가자 ${branchName} 관리자 로그인 되었습니다` });
+});
+
+// -- UP -- 회원가입: branch/user/admin -- UP --
+// --------------------------------------
+
+const riderKakaoSignup = catchAsync(async(req, res) => {
+
+    const { authorizationCode } = req.body;
+    let { companyRegistrationNumber, userName, userEmail, userPhoneNumber } = req.body;
+
+    if (!authorizationCode||!companyRegistrationNumber||!userName||!userEmail||!userPhoneNumber) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+        
+        throw error
+    }
+
+    companyRegistrationNumber = +companyRegistrationNumber;
+    userName = userName.toString();
+    userEmail = userEmail.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+
+    const kakaoAccessToken = await userService.kakaoAccessToken(authorizationCode);
+
+    if (!kakaoAccessToken) {
+        const error = new Error('KAKAO_ACCESSTOKEN_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const kakaoId = await userService.kakaoUserInfo(kakaoAccessToken);
+
+    const insertId = await userService.riderKakaoSignup(kakaoId, companyRegistrationNumber, userName, userEmail, userPhoneNumber);
+    res.status(201).json({ 'insertId': insertId });
+    
+});
+
+const riderKakaoSignin = catchAsync(async(req, res) => {
+    
+    const { authorizationCode } = req.body;
+
+    if(!authorizationCode) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const kakaoAccessToken = await userService.kakaoAccessToken(authorizationCode);
+
+    if (!kakaoAccessToken) {
+        const error = new Error('KAKAO_ACCESSTOKEN_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const kakaoId = await userService.kakaoUserInfo(kakaoAccessToken);
+
+    if (!kakaoId) {
+        const error = new Error('KAKAO_ID_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+    
+    const accessToken = await userService.riderKakaoSignin(kakaoId);
+    res.status(201).json({ 'accessToken':accessToken, 'message':'로그인 되었습니다' });
+});
+
+const riderGoogleSignup = catchAsync(async(req, res) => {
+
+    const { googleAccessToken } = req.body;
+    let { companyRegistrationNumber, userName, userEmail, userPhoneNumber } = req.body;
+
+    if (!googleAccessToken||!companyRegistrationNumber||!userName||!userEmail||!userPhoneNumber) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+        
+        throw error
+    }
+
+    companyRegistrationNumber = +companyRegistrationNumber;
+    userName = userName.toString();
+    userEmail = userEmail.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+
+    const googleUserInfo = await userService.googleUserInfo(googleAccessToken);
+    
+    if (!googleUserInfo) {
+        const error = new Error('CANNOT_GET_GOOGLE_USERINFO');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const googleId = googleUserInfo['id'];
+
+    const insertId = await userService.riderGoogleSignup(googleId, companyRegistrationNumber, userName, userEmail, userPhoneNumber);
+    res.status(201).json({ 'insertId': insertId });
+    
+});
+
+const riderGoogleSignin = catchAsync(async(req, res) => {
+    
+    const { googleAccessToken } = req.body;
+
+    if (!googleAccessToken) {
+        const error = new Error('GOOGLE_ACCESSTOKEN_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const googleUserInfo = await userService.googleUserInfo(googleAccessToken);
+
+    if (!googleUserInfo) {
+        const error = new Error('CANNOT_GET_GOOGLE_USERINFO');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const googleId = googleUserInfo['id'];
+    
+    const accessToken = await userService.riderGoogleSignin(googleId);
+    res.status(201).json({ 'accessToken':accessToken, 'message':'로그인 되었습니다' });
+});
+
+const riderNormalSignup = catchAsync(async(req, res) => {
+
+    let { companyRegistrationNumber, userName, userEmail, userPhoneNumber } = req.body;
+    const { userPassword } = req.body;
+
+    if (!companyRegistrationNumber||!userName||!userEmail||!userPassword||!userPhoneNumber) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    companyRegistrationNumber = +companyRegistrationNumber;
+    userName = userName.toString();
+    userEmail = userEmail.toString();
+    userPhoneNumber = userPhoneNumber.toString();
+    
+    const insertId = await userService.riderNormalSignup(companyRegistrationNumber, userName, userEmail, userPassword, userPhoneNumber);
+    res.status(201).json({ 'result':insertId });
+
+});
+
+const riderNormalSignin = catchAsync(async(req, res) => {
+
+    let { userEmail } = req.body;
+    const { userPassword } = req.body;
+
+    if (!userEmail||!userPassword) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    userEmail = userEmail.toString();
+
+    const jwtAccessToken = await userService.riderNormalSignin(userEmail, userPassword);
+    res.status(200).json({ 'accessToken':jwtAccessToken, 'message':'로그인 되었습니다' });
+});
+
+const riderKakaoRegister = catchAsync(async(req, res) => {
+    
+    const { authorizationCode } = req.body;
+
+    if(!authorizationCode) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const kakaoAccessToken = await userService.kakaoAccessToken(authorizationCode);
+
+    if (!kakaoAccessToken) {
+        const error = new Error('KAKAO_ACCESSTOKEN_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+    
+    const accessToken = await userService.riderKakaoRegister(kakaoAccessToken);
+
+    res.status(201).json({ 'accessToken':accessToken, 'message':'로그인 되었습니다' });
+});
+
+const riderGoogleRegister = catchAsync(async(req, res) => {
+
+    const { googleAccessToken } = req.body;
+
+    if(!googleAccessToken) {
+        const error = new Error('필수 항목들을 모두 기입했는지 확인해주세요');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const accessToken = await userService.riderGoogleRegister(googleAccessToken);
+    res.status(201).json({ 'accessToken':accessToken, 'message':'로그인 되었습니다' });
+});
+
+// -- UP -- 회원가입/로그인: user/rider -- UP --
+// --------------------------------------
+
+module.exports = {
+    sendVerificationSMS,
+    contrastVerificationCode,
+    deleteUser,
+    clientSignup,
+    clientSignin,
+    branchSignup,
+    adminSignin,
+    riderKakaoSignup,
+    riderKakaoSignin,
+    riderGoogleSignup,
+    riderGoogleSignin,
+    riderNormalSignup,
+    riderNormalSignin,
+    riderKakaoRegister,
+    riderGoogleRegister
+}

--- a/models/userDao.js
+++ b/models/userDao.js
@@ -1,0 +1,819 @@
+const appDataSource = require('./dataSource');
+
+const createUserToVerifyByPhoneNumber = async(userName, userPhoneNumber, randomFourDigit, userEmail) => {
+
+    const result = await appDataSource.query(`
+        INSERT INTO users (
+            name,
+            phone_number,
+            email,
+            verification_code
+        ) VALUES (?, ?, ?, ?);`,
+    [userName, userPhoneNumber, userEmail, randomFourDigit]
+    );
+    return result.insertId
+};
+
+const checkUserByPhoneNEmail = async(userPhoneNumber, userEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            phone_number as userPhoneNumber,
+            email as userEmail
+        FROM users
+        WHERE phone_number=? AND email=?;`,
+        [userPhoneNumber, userEmail]
+    );
+    return result[0]
+};
+
+const updateVerificationCode = async(userPhoneNumber, randomFourDigit) => {
+
+    const result = await appDataSource.query(`
+        UPDATE users
+        SET verification_code=?
+        WHERE phone_number=?;`,
+        [randomFourDigit, userPhoneNumber]
+    );
+    return result
+};
+
+const contrastVerificationCode = async(userPhoneNumber, userKeyInCode) => {
+    
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            phone_number as phoneNumber,
+            email,
+            verification_code as verificationCode
+        FROM users
+        WHERE phone_number=? AND verification_code=?;`,
+        [userPhoneNumber, userKeyInCode]
+    )
+    return result[0]
+};
+
+const deleteUser = async(userId) => {
+
+    const result = await appDataSource.query(`
+        DELETE FROM users
+        WHERE id=?;`,
+        [userId]
+    )
+    return result;
+};
+
+const getUserByPhoneNumber = async(userPhoneNumber) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            kakao_id as userKakaoId,
+            google_id as userGoogleId,
+            password as userPassword,
+            phone_number as userPhoneNumber,
+            client_id as clientId,
+            client_admin as clientAdmin
+        FROM users
+        WHERE phone_number=?;`,
+        [userPhoneNumber]
+    )
+    return result[0];
+}
+
+const getUserByEmail = async(userEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            phone_number as userPhoneNumber,
+            email as userEmail,
+            password as hashedUserPassword
+        FROM users
+        WHERE email=?;`,
+        [userEmail]
+    )
+    return result[0]
+}
+
+const getUserById = async(userId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            phone_number as userPhoneNumber,
+            email as userEmail,
+            client_id as clientId,
+            client_admin as clientAdmin
+        FROM users
+        WHERE id=?;`,
+        [userId]
+    )
+    return result[0]
+}
+
+const getUserByKakaoId = async(kakaoId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            phone_number as userPhoneNumber,
+            kakao_id as kakaoId,
+            google_id as googleId
+        FROM users
+        WHERE kakao_id=?;`,
+        [kakaoId]
+    )
+    return result[0]
+};
+
+const getUserBygoogleId = async(googleId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            phone_number as userPhoneNumber,
+            kakao_id as kakaoId,
+            google_id as googleId
+        FROM users
+        WHERE google_id=?;`,
+        [googleId]
+    )
+    return result[0]
+}
+
+const getClientAdminByClientId = async(clientId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            client_id as clientId,
+            client_admin as clientAdmin
+        FROM users
+        WHERE client_id=? AND client_admin=1;`,
+        [clientId]
+    )
+    return result[0];
+}
+
+// -- UP -- 회원가입: 전화번호 인증 구현 -- UP --
+// --------------------------------------
+const getClientByRegistrationNumber = async(companyRegistrationNumber) => {
+    
+    const result = await appDataSource.query(`
+        SELECT
+            id as clientId,
+            company_name as companyName,
+            registration_number as companyRegistrationNumber
+        FROM clients
+        WHERE registration_number=?;`,
+        [companyRegistrationNumber]
+    )
+    return result[0];
+}
+
+const getClientByEmail = async(companyEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as clientId,
+            company_name as companyName,
+            email as companyEmail,
+            password as hashedCompanyPassword
+        FROM clients
+        WHERE email=?;`,
+        [companyEmail]
+    )
+    return result[0];
+};
+
+const getClientByName = async(companyName) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id,
+            company_name as companyName,
+            registration_number as registrationNumber,
+            email as companyEmail
+        FROM clients
+        WHERE company_name=?;`,
+        [companyName]
+    )
+    return result[0];
+}
+
+const getClientByClientId = async(clientId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as clientId,
+            company_name as companyName,
+            registration_number as registrationNumber,
+            email as companyEmail
+        FROM clients
+        WHERE id=?;`,
+        [clientId]
+    )
+    return result[0];
+}
+
+const clientSignup = async(companyName, companyRegistrationNumber, companyEmail, hashedCompanyPassword, userName, userEmail, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const createClient = await queryRunner.query(`
+            INSERT INTO clients (
+                company_name,
+                registration_number,
+                email,
+                password
+            ) VALUES (?, ?, ?, ?);`,
+            [companyName, companyRegistrationNumber, companyEmail, hashedCompanyPassword]
+        )
+
+        const clientId = await createClient.insertId;
+        const clientAdmin = 1;
+
+        const user = await getUserByPhoneNumber(userPhoneNumber);
+
+        if(!user) {
+            const error = new Error(`${userPhoneNumber}은 존재하지 않는 사용자입니다`); 
+            error.statusCode = 401;
+    
+            throw error
+        };
+
+        if(typeof(user['clientId'])==='number' && typeof(user['clientAdmin'])==='number') {
+            const error = new Error(`${userPhoneNumber}는 이미 다른 회사의 관리자로 회원가입된 상태입니다`);
+            error.statusCode = 401;
+    
+            throw error
+        }
+
+        if(typeof(user['clientId'])==='number' && user['clientAdmin']===null) {
+            const error = new Error(`${userPhoneNumber}는 이미 다른 회사의 rider로 회원가입된 상태입니다`);
+            error.statusCode = 401;
+    
+            throw error
+        }
+
+        const updateUser = await queryRunner.query(`
+            UPDATE users
+            SET
+                name=?,
+                email=?,
+                client_id=?,
+                client_admin=?
+            WHERE phone_number=?;`,
+        [userName, userEmail, clientId, clientAdmin, userPhoneNumber]
+        )
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return updateUser;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+// -- UP -- 회원가입: client/user 회원가입/로그인 구현 -- UP --
+// --------------------------------------
+
+const getBranchByName = async(branchName) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            name as branchName,
+            address as branchAddress,
+            email as branchEmail
+        FROM branches
+        WHERE name=?;`,
+        [branchName]
+    )
+    return result[0];
+};
+
+const getBranchByEmail = async(branchEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as branchId,
+            name as branchName,
+            address as branchAddress,
+            email as branchEmail,
+            password as hashedBranchPassword
+        FROM branches
+        WHERE email=?;`,
+        [branchEmail]
+    )
+    return result[0];
+};
+
+const getAdminByBranchId = async(branchId) => {
+    
+    const result = await appDataSource.query(`
+        SELECT
+            id as adminId,
+            user_id as adminUserId,
+            branch_id as adminBranchId,
+            riderlog_editor as adminRiderlogEditor
+        FROM admins
+        WHERE branch_id=?;`,
+        [branchId]
+    )
+    return result[0];
+};
+
+const getAdminByBranchEmail = async(branchEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            b.id as branchId,
+            b.name as branchName,
+            a.id as adminId,
+            a.user_id as adminUserId,
+            a.riderlog_editor as riderlogEditor
+        FROM branches b
+        INNER JOIN admins a ON b.id=a.branch_id
+        WHERE b.email=?;`,
+        [branchEmail]
+    )
+    return result[0];
+};
+
+const getAdminByAdminId = async(adminId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as adminId,
+            user_id as adminUserId,
+            branch_id as branchId,
+            riderlog_editor as riderlogEditor
+        FROM admin
+        WHERE id=?;`,
+        [adminId]
+    )
+    return result[0];
+}
+
+const branchSignup = async(branchName, branchAddress, branchLatitude, branchLongitude, branchEmail, hashedBranchPassword, userName, userEmail, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const createBranch = await queryRunner.query(`
+            INSERT INTO branches (
+                name,
+                address,
+                latitude,
+                longitude,
+                email,
+                password
+            ) VALUES (?, ?, ?, ?, ?, ?);`,
+        [branchName, branchAddress, branchLatitude, branchLongitude, branchEmail, hashedBranchPassword]
+        );
+
+        await queryRunner.query(`
+            UPDATE users
+            SET
+                name=?,
+                email=?
+            WHERE phone_number=?;`,
+        [userName, userEmail, userPhoneNumber]
+        )
+
+        const user = await getUserByPhoneNumber(userPhoneNumber);
+
+        if(!user) {
+            const error = new Error(`${userPhoneNumber}은 존재하지 않는 사용자입니다`);
+            error.statusCode = 401;
+    
+            throw error
+        };
+
+        const userId = user.userId;
+        const branchId = createBranch.insertId;
+        const riderlogEditor = 1;
+
+        const createAdmin = await queryRunner.query(`
+            INSERT INTO admins (
+                user_id,
+                branch_id,
+                riderlog_editor
+            ) VALUES (?, ?, ?);`,
+            [userId, branchId, riderlogEditor]
+            )
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createAdmin.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+// -- UP -- 회원가입: branch/user/admin -- UP --
+// --------------------------------------
+
+
+const getUserByKaKaoId = async(kakaoId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            kakao_id as kakaoId,
+            google_id as googleId,
+            phone_number as userPhoneNumber,
+            email as userEmail,
+            client_id as clientId,
+            client_admin as clientAdmin
+        FROM users
+        WHERE kakao_id=?;`,
+        [kakaoId]
+    );
+    return result[0];
+};
+
+const getUserByGoogleId = async(googleId) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            id as userId,
+            name as userName,
+            kakao_id as kakaoId,
+            google_id as googleId,
+            phone_number as userPhoneNumber,
+            email as userEmail,
+            client_id as clientId,
+            client_admin as clientAdmin
+        FROM users
+        WHERE google_id=?;`,
+        [googleId]
+    )
+    return result[0];
+};
+
+const updateUserKakao = async(kakaoId, clientId, userName, userEmail, userPhoneNumber) => {
+
+    const result = await appDataSource.query(`
+        UPDATE users
+        SET
+            name=?,
+            kakao_id=?,
+            email=?,
+            client_id=?
+        WHERE phone_number=?;`,
+        [userName, kakaoId, userEmail, clientId, userPhoneNumber]   
+    )
+    return result;
+};
+
+
+const riderKakaoSignup = async(kakaoId, companyRegistrationNumber, userName, userEmail, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const client = await getClientByRegistrationNumber(companyRegistrationNumber);
+        const clientRegistrationNumber = client['companyRegistrationNumber'];
+        const companyName = client['companyName'];
+        const clientId = client['clientId'];
+
+        if(!clientRegistrationNumber) {
+            const error = new Error('등록되지 않은 회사입니다. 소속 사업장에 문의해주세요');
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        const getUserInfo = await getUserByPhoneNumber(userPhoneNumber);
+        const checkUserIsAdmin = getUserInfo['clientAdmin'];
+
+        if (checkUserIsAdmin === 1) {
+            const error = new Error(`${companyName}의 관리자로 등록되어 있습니다. 회사계정으로 서비스를 이용해주세요`);
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        let user = await getUserByKaKaoId(kakaoId);
+
+        if(user) {
+            const error = new Error(`${userPhoneNumber}는 이미 kakao 소셜로그인으로 회원가입 완료된 사용자입니다`);
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        await updateUserKakao(kakaoId, clientId, userName, userEmail, userPhoneNumber);
+
+        const userId = getUserInfo['userId'];
+
+        const createRider = await queryRunner.query(`
+            INSERT INTO riders (
+                user_id
+            ) VALUES (?);`,
+            [userId]    
+        );
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createRider.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+const getRiderByuserPhoneNumber = async(userPhoneNumber) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            r.id as riderId,
+            r.user_id as userId,
+            u.name as userName
+        FROM riders r
+        INNER JOIN users u ON r.user_id=u.id
+        WHERE u.phone_number=?;`,
+        [userPhoneNumber]
+    )
+    return result[0];
+};
+
+const getRiderByuserEmail = async(userEmail) => {
+
+    const result = await appDataSource.query(`
+        SELECT
+            r.id as riderId,
+            r.user_id as userId,
+            u.name as userName
+        FROM riders r
+        INNER JOIN users u ON r.user_id=u.id
+        WHERE u.email=?;`,
+        [userEmail]
+    )
+    return result[0];
+};
+
+const riderGoogleSignup = async(googleId, companyRegistrationNumber, userName, userEmail, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const client = await getClientByRegistrationNumber(companyRegistrationNumber);
+        const clientRegistrationNumber = client['companyRegistrationNumber'];
+        const companyName = client['companyName'];
+        const clientId = client['clientId'];
+
+        if(!clientRegistrationNumber) {
+            const error = new Error('등록되지 않은 회사입니다. 소속 사업장에 문의해주세요');
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        const getUserInfo = await getUserByPhoneNumber(userPhoneNumber);
+        const checkUserIsAdmin = getUserInfo['clientAdmin'];
+
+        if (checkUserIsAdmin === 1) {
+            const error = new Error(`${companyName}의 관리자로 등록되어 있습니다. 회사계정으로 서비스를 이용해주세요`);
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        let user = await getUserBygoogleId(googleId);
+
+        if(user) {
+            const error = new Error(`${userPhoneNumber}는 이미 google 소셜로그인으로 회원가입 완료된 사용자입니다`);
+            error.statusCode = 401;
+            
+            throw error
+        };
+
+        const result = await queryRunner.query(`
+            UPDATE users
+            SET
+                name=?,
+                google_id=?,
+                email=?,
+                client_id=?
+            WHERE phone_number=?;`,
+            [userName, googleId, userEmail, clientId, userPhoneNumber]   
+        )
+
+        const userId = getUserInfo['userId'];
+
+        const createRider = await queryRunner.query(`
+            INSERT INTO riders (
+                user_id
+            ) VALUES (?);`,
+            [userId]    
+        );
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createRider.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+const riderNormalSignup = async(companyRegistrationNumber, userName, userEmail, hashedUserPassword, userPhoneNumber) => {
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const client = await getClientByRegistrationNumber(companyRegistrationNumber);
+        const companyName = client['companyName'];
+        const clientId = client['clientId'];
+
+        const getUserInfo = await getUserByPhoneNumber(userPhoneNumber);
+        const checkUserIsAdmin = getUserInfo['clientAdmin'];
+
+        if (checkUserIsAdmin === 1) {
+            return `${companyName}의 관리자로 등록되어 있습니다. 회사계정으로 서비스를 이용해주세요`;
+        };
+
+        await queryRunner.query(`
+            UPDATE users
+            SET
+                name=?,
+                email=?,
+                password=?,
+                client_id=?
+            WHERE phone_number=?;`,
+            [userName, userEmail, hashedUserPassword, clientId, userPhoneNumber]
+        );
+
+        const userId = getUserInfo['userId'];
+
+        const createRider = await queryRunner.query(`
+            INSERT INTO riders (
+                user_id
+            ) VALUES (?);`,
+            [userId]    
+        );
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createRider.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+const riderKakaoRegister = async(kakaoId, kakaoName, kakaoEmail, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const createUser = await queryRunner.query(`
+                INSERT INTO users (
+                    kakao_id,
+                    name,
+                    email,
+                    phone_number
+                ) VALUES (?, ?, ?, ?);`,
+            [kakaoId, kakaoName, kakaoEmail, userPhoneNumber]
+        )
+        
+        const userId = createUser.insertId;
+
+        const createRider = await queryRunner.query(`
+            INSERT INTO riders (
+                user_id
+            ) VALUES (?);`,
+            [userId]    
+        );
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createRider.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+const riderGoogleRegister = async(googleId, googleEmail, userName, userPhoneNumber) => {
+
+    const queryRunner = appDataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+        const createUser = await queryRunner.query(`
+            INSERT INTO users (
+                google_id,
+                name,
+                email,
+                phone_number
+            ) VALUES (?, ?, ?, ?);`,
+        [googleId, userName, googleEmail, userPhoneNumber]
+        );
+
+        const userId = createUser.insertId
+
+        const createRider = await queryRunner.query(`
+            INSERT INTO riders (
+                user_id
+            ) VALUES (?);`,
+            [userId]    
+        );
+
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+
+        return createRider.insertId;
+
+    } catch (error) {
+        await queryRunner.rollbackTransaction();
+        return error.message;
+    } finally {
+        await queryRunner.release();
+    }
+};
+
+// -- UP -- 회원가입/로그인: user/rider -- UP --
+// --------------------------------------
+
+module.exports = {
+    createUserToVerifyByPhoneNumber,
+    checkUserByPhoneNEmail,
+    updateVerificationCode,
+    contrastVerificationCode,
+    deleteUser,
+    getUserByPhoneNumber,
+    getUserByEmail,
+    getUserById,
+    getUserByKakaoId,
+    getUserBygoogleId,
+    getClientAdminByClientId,
+    getClientByRegistrationNumber,
+    getClientByEmail,
+    getClientByName,
+    getClientByClientId,
+    clientSignup,
+    getBranchByName,
+    getBranchByEmail,
+    getAdminByBranchId,
+    getAdminByBranchEmail,
+    getAdminByAdminId,
+    branchSignup,
+    getRiderByuserPhoneNumber,
+    getRiderByuserEmail,
+    riderNormalSignup,
+    getUserByKaKaoId,
+    getUserByGoogleId,
+    riderKakaoSignup,
+    riderGoogleSignup,
+    riderKakaoRegister,
+    riderGoogleRegister
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bcrypt": "^5.1.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
+        "crypto-js": "^4.1.1",
         "dbmate": "^1.0.3",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -646,6 +647,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/date-fns": {
       "version": "2.29.3",
@@ -3280,6 +3286,11 @@
         "object-assign": "^4",
         "vary": "^1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "date-fns": {
       "version": "2.29.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bcrypt": "^5.1.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "crypto-js": "^4.1.1",
     "dbmate": "^1.0.3",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,7 +1,9 @@
 const router = require('express').Router();
 
+const userRouter = require('./userRouter');
 const postRouter = require('./postRouter');
 
+router.use('/user', userRouter);
 router.use('/post', postRouter);
 
 module.exports = router;

--- a/routes/userRouter.js
+++ b/routes/userRouter.js
@@ -1,0 +1,20 @@
+const router = require('express').Router();
+const userController = require('../controllers/userController');
+
+router.post('/sendSMS', userController.sendVerificationSMS);
+router.post('/contrastCode', userController.contrastVerificationCode);
+router.post('/clientSignup', userController.clientSignup);
+router.post('/clientSignin', userController.clientSignin);
+router.post('/branchSignup', userController.branchSignup);
+router.post('/adminSignin', userController.adminSignin);
+router.post('/riderNormalSignup', userController.riderNormalSignup);
+router.post('/riderNormalSignin', userController.riderNormalSignin);
+router.post('/riderKakaoSignup', userController.riderKakaoSignup);
+router.post('/riderKakaoSignin', userController.riderKakaoSignin);
+router.post('/riderGoogleSignup', userController.riderGoogleSignup);
+router.post('/riderGoogleSignin', userController.riderGoogleSignin);
+router.post('/riderKakaoRegister', userController.riderKakaoRegister); // 임시기능
+router.post('/riderGoogleRegister', userController.riderGoogleRegister); // 임시기능
+router.delete('', userController.deleteUser);
+
+module.exports = router;

--- a/services/userService.js
+++ b/services/userService.js
@@ -1,0 +1,685 @@
+const axios = require('axios');
+const CryptoJS = require('crypto-js');
+const bcrypt = require('bcrypt');
+const qs = require('qs');
+const jwt = require('jsonwebtoken');
+const userDao = require('../models/userDao');
+
+const { SENS_ACCESSKEY, SENS_SECRETKEY, SENS_SERVICEID} = process.env;
+const timestamp = String(Date.now());
+const partialUrl = `/sms/v2/services/${SENS_SERVICEID}/messages`;
+
+const makeSignature = async() => {
+	const space = " ";
+	const newLine = "\n";
+	const method = "POST";
+
+	var hmac = CryptoJS.algo.HMAC.create(CryptoJS.algo.SHA256, SENS_SECRETKEY);
+        hmac.update(method);
+        hmac.update(space);
+        hmac.update(partialUrl);
+        hmac.update(newLine);
+        hmac.update(timestamp);
+        hmac.update(newLine);
+        hmac.update(SENS_ACCESSKEY);
+
+	const hash = hmac.finalize();
+    const signature = hash.toString(CryptoJS.enc.Base64);
+
+	return signature;
+};
+
+const sendAuthSMS = async (randomFourDigit, userPhoneNumber) => {
+    const signature = await makeSignature();
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const sendSMS = await axios({
+        method: 'post',
+        url: `https://sens.apigw.ntruss.com${partialUrl}`,
+        headers: {
+            'Content-Type': 'application/json; charset=utf-8',
+            'x-ncp-apigw-timestamp': timestamp,
+            'x-ncp-iam-access-key': SENS_ACCESSKEY,
+            'x-ncp-apigw-signature-v2': signature
+        },
+        data: {
+                'type':'SMS',
+                'contentType':'COMM',
+                'countryCode':'82',
+                'from':'01051509714',
+                'subject':'별따러가자 핸드폰 인증',
+                'content': '별따러가자 인증문자',
+                'messages':[
+                    {
+                        'to': `${userPhoneNumber}`,
+                        'subject':'별따러가자 핸드폰 인증',
+                        'content': `별따러가자 본인확인 인증번호 [${randomFourDigit}]를 입력해주세요`
+                    }
+                ]
+        }
+    }).then(response => response.data);
+
+    return sendSMS;
+};
+
+const checkUserByPhoneNEmail = async(userName, userPhoneNumber, randomFourDigit, userEmail) => { 
+    
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+    await emailRegularExpression(userEmail);
+
+    const user = await userDao.checkUserByPhoneNEmail(userPhoneNumber, userEmail);
+
+    if (!user)  {
+        const checkUserByEmail = await userDao.getUserByEmail(userEmail);
+        const checkUserByPhoneNumber = await userDao.getUserByPhoneNumber(userPhoneNumber);
+
+        if(checkUserByEmail) {
+            const error = new Error(`${userEmail}는 이미 가입된 사용자입니다`);
+            error.statusCode = 400;
+
+            throw error
+        }
+
+        if(checkUserByPhoneNumber) {
+            const error = new Error(`${userPhoneNumber}는 이미 가입된 사용자입니다`);
+            error.statusCode = 400;
+
+            throw error
+        }
+
+        await userDao.createUserToVerifyByPhoneNumber(userName, userPhoneNumber, randomFourDigit, userEmail);
+    }
+
+    if (user) {
+        const userInfo = await userDao.getUserByPhoneNumber(userPhoneNumber);
+        const kakaoId = userInfo['userKakaoId'];
+        const googleId = userInfo['userGoogleId'];
+        const password = userInfo['userPassword'];
+        const clientAdmin = userInfo['clientAdmin'];
+
+        if (clientAdmin===1||kakaoId||googleId||password) {
+            let platform = '';
+            if(clientAdmin===1) {
+                const clientId = userInfo['clientId'];
+                const client = await userDao.getClientByClientId(clientId);
+                const companyName = client['companyName'];
+                
+                platform = `${companyName}의 관리자로 `
+            } else if (kakaoId) {
+                platform = 'kakao로 '
+            } else if (googleId) {
+                platform = 'google로 '
+            } else if (password) {
+                platform = '일반 회원가입으로 '
+            }
+
+            const error = new Error(`${userPhoneNumber}는 이미 ${platform}가입된 사용자입니다`);
+            error.statusCode = 400;
+
+            throw error
+        };
+
+        await userDao.updateVerificationCode(userPhoneNumber, randomFourDigit);
+    }
+
+    return await sendAuthSMS(randomFourDigit, userPhoneNumber);
+};
+
+const deleteUser = async(userPhoneNumber) => {
+
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const user = await userDao.getUserByPhoneNumber(userPhoneNumber);
+
+    if(!user) {
+        const error = new Error(`${userPhoneNumber}은 존재하지 않는 사용자입니다`);
+        error.statusCode = 400;
+
+        throw error
+    }
+
+    const result = await userDao.deleteUser(user.userId);
+    return result
+};
+
+const contrastVerificationCode = async(userPhoneNumber, userKeyInCode) => {
+
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const verification = await userDao.contrastVerificationCode(userPhoneNumber, userKeyInCode);
+
+    if(verification) {return '휴대폰번호 인증 완료되었습니다'};
+
+    if(!verification) {
+        await deleteUser(userPhoneNumber);
+
+        const error = new Error('인증번호가 일치하지 않습니다. 휴대폰번호를 재전송해주세요');
+        error.statusCode = 400;
+
+        throw error
+    };
+};
+
+const userPhoneNumberRegularExpression = async(userPhoneNumber) => {
+    
+    const USER_PHONE_NUM_REGEX =/^(010)([0-9]{3,4})([0-9]{4})$/
+
+    if(!USER_PHONE_NUM_REGEX.test(userPhoneNumber)) {
+        const error = new Error(`휴대폰번호 형식이 올바르지 않습니다.'-'기호를 제외한 번호를 입력해주세요`);
+        error.statusCode = 400;
+
+        throw error
+    }
+};
+
+const emailRegularExpression = async(email) => {
+    const EMAILREGEX =/^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/
+
+    if(!EMAILREGEX.test(email)) {
+        const error = new Error('메일주소 형식이 올바르지 않습니다');
+        error.statusCode = 400;
+
+        throw error
+    }
+};
+
+const passwordRegularExpression = async(companyPassword) => {
+    const PWREGEX =/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})/
+
+    if(!PWREGEX.test(companyPassword)) {
+        const error = new Error('비밀번호 형식이 올바르지 않습니다');
+        error.statusCode = 400;
+
+        throw error
+    }
+};
+
+const companyRegistrationNumberRegularExpression = async(companyRegistrationNumber) => {
+    const COMPANY_REGIST_NUM_REGEX =/^(?=.*[0-9]{10})/
+
+    if(!COMPANY_REGIST_NUM_REGEX.test(companyRegistrationNumber)) {
+        const error = new Error(`사업자등록번호 형식이 올바르지 않습니다. '-'기호를 제외하고 10자리 숫자만 입력해주세요`);
+        error.statusCode = 400;
+
+        throw error
+    }
+};
+
+const hashPassword = async(plainPassword) => {
+    const saltRounds = 12;
+    const salt = await bcrypt.genSalt(saltRounds);
+    return await bcrypt.hash(plainPassword, salt);
+};
+
+const checkHash = async(plainPassword, hashedPassword) => {
+    return await bcrypt.compare(plainPassword, hashedPassword);
+};
+
+const createJWTAccessToken = async(userId) => {
+
+    const { ALGORITHM, JWT_SECRET, JWT_EXPIRES_IN } = process.env;
+
+    const jwtAccessToken = jwt.sign({'userId':userId}, JWT_SECRET, {
+        algorithm: ALGORITHM,
+        expiresIn: JWT_EXPIRES_IN
+    });
+
+    return jwtAccessToken;
+};
+
+const clientSignup = async(companyName, companyRegistrationNumber, companyEmail, companyPassword, userName, userEmail, userPhoneNumber) => {
+
+    await companyRegistrationNumberRegularExpression(companyRegistrationNumber);
+    await emailRegularExpression(companyEmail);
+    await passwordRegularExpression(companyPassword);
+    await emailRegularExpression(userEmail);
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const clientName = await userDao.getClientByName(companyName);
+    const clientRegistrationNumber = await userDao.getClientByRegistrationNumber(companyRegistrationNumber);
+    const clientEmail = await userDao.getClientByEmail(companyEmail);
+
+    if(clientName) {
+        const error = new Error(`${companyName}은 이미 회원가입된 회사명 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    };
+
+    if(clientRegistrationNumber) {
+        const error = new Error(`${companyRegistrationNumber}은 이미 회원가입된 사업자등록번호 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    };
+
+    if(clientEmail) {
+        const error = new Error(`${companyEmail}은 이미 회원가입된 메일주소 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    };
+
+    const hashedCompanyPassword = await hashPassword(companyPassword);
+
+    return await userDao.clientSignup(companyName, companyRegistrationNumber, companyEmail, hashedCompanyPassword, userName, userEmail, userPhoneNumber);
+};
+
+const clientSignin = async(companyEmail, companyPassword) => {
+
+    await passwordRegularExpression(companyPassword);
+    await emailRegularExpression(companyEmail);
+
+    const client = await userDao.getClientByEmail(companyEmail);
+
+    if(!client) {
+        const error = new Error('존재하지 않는 메일주소 입니다');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const clientId = client['clientId'];
+
+    const hashedCompanyPassword = client['hashedCompanyPassword'];
+    const contrastPassword = await checkHash(companyPassword, hashedCompanyPassword);
+
+    if(!contrastPassword) {
+        const error = new Error('존재하지 않는 비밀번호 입니다');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const user = await userDao.getClientAdminByClientId(clientId);
+
+    return await createJWTAccessToken(user.userId);
+}
+
+// -- UP -- 회원가입: client/user 회원가입/로그인 구현 -- UP --
+// --------------------------------------
+
+const addressToCoordinates = async(address) => {
+    
+    const { KAKAO_REST_API_KEY } = process.env
+    const beforeEncoding = `https://dapi.kakao.com/v2/local/search/address.json?query=${address}`
+    const URL = encodeURI(beforeEncoding);
+
+    const convert = await axios({
+        method: 'get',
+        url: URL,
+        headers: {
+            'Authorization': `KakaoAK ${KAKAO_REST_API_KEY}`
+        }
+    }).then(response => response.data.documents[0]);
+
+    const coordinates = {};
+    coordinates['x'] = convert['x'];
+    coordinates['y'] = convert['y'];
+    
+    return coordinates
+};
+
+// -- UP -- 주소를 경위도 좌표로 변화 -- UP --
+const branchSignup = async(branchName, branchAddress, branchEmail, branchPassword, userName, userEmail, userPhoneNumber) => {
+
+    await passwordRegularExpression(branchPassword);
+    await emailRegularExpression(branchEmail);
+    await emailRegularExpression(userEmail);
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const name = await userDao.getBranchByName(branchName).branchName;
+    const email = await userDao.getBranchByEmail(branchEmail).branchEmail;
+
+    if(name) {
+        const error = new Error(`${name}은 이미 등록된 지점명 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    };
+
+    if(email) {
+        const error = new Error(`${email}은 이미 등록된 메일주소 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    };
+
+    const hashedBranchPassword = await hashPassword(branchPassword);
+
+    const coordinates = await addressToCoordinates(branchAddress);
+
+    const branchLatitude = coordinates['x'];
+    const branchLongitude = coordinates['y'];
+
+    return await userDao.branchSignup(branchName, branchAddress, branchLatitude, branchLongitude, branchEmail, hashedBranchPassword, userName, userEmail, userPhoneNumber);
+};
+
+const getBranchByEmail = async(branchEmail) => {
+
+    return await userDao.getBranchByEmail(branchEmail);
+};
+
+const getAdminByBranchEmail = async(branchEmail) => {
+
+    return await userDao.getAdminByBranchEmail(branchEmail);
+};
+
+const adminSignin = async(branchEmail, branchPassword) => {
+
+    await passwordRegularExpression(branchPassword);
+    await emailRegularExpression(branchEmail);
+
+    const branch = await userDao.getBranchByEmail(branchEmail);
+
+    if(!branch) {
+        const error = new Error(`${branchEmail}은 존재하지 않는 메일주소 입니다`);
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const hashedBranchPassword = branch['hashedBranchPassword'];
+    const contrastPassword = await checkHash(branchPassword, hashedBranchPassword);
+
+    if(!contrastPassword) {
+        const error = new Error('존재하지 않는 비밀번호 입니다')
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    const branchId = branch['branchId'];
+    const admin = await userDao.getAdminByBranchId(branchId);
+    const adminId = admin['adminId'];
+
+    return await createJWTAccessToken(adminId);
+};
+
+// -- UP -- 회원가입: branch/user/admin -- UP --
+// --------------------------------------
+
+const kakaoAccessToken = async(authorizationCode) => {
+
+    const { KAKAO_REST_API_KEY, KAKAO_REDIRECT_URI } = process.env;
+
+    return await axios({
+        method: 'post',
+        url: 'https://kauth.kakao.com/oauth/token',
+        headers: {
+        'Content-type':'application/x-www-form-urlencoded;charset=utf-8'
+        },
+        data: qs.stringify({
+            grant_type: 'authorization_code',
+            client_id: KAKAO_REST_API_KEY,
+            redirect_uri: KAKAO_REDIRECT_URI,
+            code: authorizationCode
+        })
+    }).then(response => response.data['access_token'])
+    .catch(err => console.log("error " + err));
+};
+
+const kakaoUserInfo = async(kakaoAccessToken) => {
+
+    return await axios ({
+        method: 'get',
+        url: 'https://kapi.kakao.com//v2/user/me',
+        headers: {
+            'Content-type':'application/x-www-form-urlencoded;charset=utf-8',
+            'Authorization': `Bearer ${kakaoAccessToken}`
+        }
+    }).then(response => response.data.id)
+    .catch(err => console.log("error " + err));
+};
+
+const riderKakaoSignup = async(kakaoId, companyRegistrationNumber, userName, userEmail, userPhoneNumber) => {
+
+    await emailRegularExpression(userEmail);
+    await companyRegistrationNumberRegularExpression(companyRegistrationNumber);
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const user = await userDao.getUserByKakaoId(kakaoId);
+
+    if(user) {
+        const error = new Error(`${userPhoneNumber}는 이미 kakao로 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    const riderByPhoneNumber = await userDao.getRiderByuserPhoneNumber(userPhoneNumber);
+    const riderByEmail = await userDao.getRiderByuserEmail(userEmail);
+
+    if(riderByPhoneNumber) {
+        const error = new Error(`${userPhoneNumber}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    if(riderByEmail) {
+        const error = new Error(`${userEmail}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    return await userDao.riderKakaoSignup(kakaoId, companyRegistrationNumber, userName, userEmail, userPhoneNumber);
+};
+
+const riderKakaoSignin = async(kakaoId) => {
+
+    const user = await userDao.getUserByKakaoId(kakaoId);
+    
+    return await createJWTAccessToken(user.userId);
+};
+
+const riderGoogleSignup = async(googleId, companyRegistrationNumber, userName, userEmail, userPhoneNumber) => {
+
+    await emailRegularExpression(userEmail);
+    await companyRegistrationNumberRegularExpression(companyRegistrationNumber);
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const user = await userDao.getUserBygoogleId(googleId);
+
+    if(user) {
+        const error = new Error(`${userPhoneNumber}는 이미 google로 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    const riderByPhoneNumber = await userDao.getRiderByuserPhoneNumber(userPhoneNumber);
+    const riderByEmail = await userDao.getRiderByuserEmail(userEmail);
+
+    if(riderByPhoneNumber) {
+        const error = new Error(`${userPhoneNumber}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    if(riderByEmail) {
+        const error = new Error(`${userEmail}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    return await userDao.riderGoogleSignup(googleId, companyRegistrationNumber, userName, userEmail, userPhoneNumber);
+};
+
+const riderGoogleSignin = async(googleId) => {
+
+    const user = await userDao.getUserByGoogleId(googleId);
+    
+    return await createJWTAccessToken(user.userId);
+};
+
+
+const riderNormalSignup = async(companyRegistrationNumber, userName, userEmail, userPassword, userPhoneNumber) => {
+
+    await passwordRegularExpression(userPassword);
+    await emailRegularExpression(userEmail);
+    await companyRegistrationNumberRegularExpression(companyRegistrationNumber);
+    await userPhoneNumberRegularExpression(userPhoneNumber);
+
+    const clientRegistrationNumber = await userDao.getClientByRegistrationNumber(companyRegistrationNumber);
+
+    if(!clientRegistrationNumber) {
+        const error = new Error('존재하지 않는 사업자등록번호 입니다. 소속 사업장에 문의해주세요')
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    const riderByPhoneNumber = await userDao.getRiderByuserPhoneNumber(userPhoneNumber);
+    const riderByEmail = await userDao.getRiderByuserEmail(userEmail);
+
+    if(riderByPhoneNumber) {
+        const error = new Error(`${userPhoneNumber}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    if(riderByEmail) {
+        const error = new Error(`${userEmail}는 이미 가입된 사용자입니다`)
+        error.statusCode = 401;
+
+        throw error 
+    }
+
+    const hashedUserPassword = await hashPassword(userPassword);
+    return await userDao.riderNormalSignup(companyRegistrationNumber, userName, userEmail, hashedUserPassword, userPhoneNumber);
+
+};
+
+const riderNormalSignin = async(userEmail, userPassword) => {
+
+    await passwordRegularExpression(userPassword);
+    await emailRegularExpression(userEmail);
+
+    const user = await userDao.getUserByEmail(userEmail);
+
+    if(!user) {
+        const error = new Error('존재하지 않는 메일주소 입니다');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    const hashedUserPassword = user['hashedUserPassword'];
+    const contrastPassword = await checkHash(userPassword, hashedUserPassword);
+
+    if(!contrastPassword) {
+        const error = new Error('존재하지 않는 비밀번호 입니다');
+        error.statusCode = 401;
+
+        throw error
+    }
+
+    return await createJWTAccessToken(user.userId);
+};
+
+const riderKakaoRegister = async(kakaoAccessToken) => {
+
+    const kakaoUser = await kakaoUserInfo(kakaoAccessToken);
+    const kakaoId = kakaoUser['id'];
+    const kakaoName = kakaoUser['properties']['nickname'];
+    const kakaoEmail = kakaoUser['kakao_account']['email'];
+    const userPhoneNumber = '010' + String(Math.floor(Math.random()*(100000000-10000000)) + 10000000);
+
+    await emailRegularExpression(kakaoEmail);
+    
+    let user = await userDao.getUserByKaKaoId(kakaoId);
+
+    if(!user) {
+        const result = await userDao.riderKakaoRegister(kakaoId, kakaoName, kakaoEmail, userPhoneNumber);
+        if (typeof(result)!=='number') {
+            const error = new Error('카카오 라이더 생성과정에서 문제가 생겼습니다');
+            error.statusCode = 401;
+    
+            throw error
+        }
+    }
+
+    user = await userDao.getUserByKaKaoId(kakaoId);
+    return await createJWTAccessToken(user.userId);
+};
+
+const googleUserInfo = async(googleAccessToken) => {
+
+    return await axios({
+        method:'get',
+        url:`https://www.googleapis.com/oauth2/v1/userinfo?access_token=${googleAccessToken}`,
+        headers: {
+            'Content-Type':'application/json'
+        }
+    }).then(response => response.data)
+    
+    .catch(err => console.log('error ' + err));
+};
+
+const riderGoogleRegister = async(googleAccessToken) => {
+
+    const userInfo = await googleUserInfo(googleAccessToken);
+
+    if (!userInfo) {
+        const error = new Error('GOOGLE_ACCESSTOKEN_IS_NOT_VALID');
+        error.statusCode = 401;
+        
+        throw error
+    };
+
+    const googleId = userInfo['id'];
+    const googleEmail = userInfo['email'];
+    const googleName = userInfo['name'];
+    const userPhoneNumber = '010' + String(Math.floor(Math.random()*(100000000-10000000)) + 10000000);
+
+    await emailRegularExpression(googleEmail);
+
+    let user = await userDao.getUserByGoogleId(googleId);
+
+    if(!user) {
+        const result = await userDao.riderGoogleRegister(googleId, googleEmail, googleName, userPhoneNumber);
+
+        if (typeof(result)!=='number') {
+            const error = new Error('구글 라이더 생성과정에서 문제가 생겼습니다');
+            error.statusCode = 401;
+    
+            throw error
+        }
+    }
+
+    user = await userDao.getUserByGoogleId(googleId);
+    return await createJWTAccessToken(user.userId);
+};
+
+// -- UP -- 회원가입: user/rider -- UP --
+// --------------------------------------
+
+module.exports = {
+    sendAuthSMS,
+    checkUserByPhoneNEmail,
+    contrastVerificationCode,
+    deleteUser,
+    clientSignup,
+    clientSignin,
+    branchSignup,
+    getBranchByEmail,
+    getAdminByBranchEmail,
+    adminSignin,
+    kakaoAccessToken,
+    kakaoUserInfo,
+    googleUserInfo,
+    createJWTAccessToken,
+    riderKakaoSignup,
+    riderKakaoSignin,
+    riderGoogleSignup,
+    riderGoogleSignin,
+    riderNormalSignup,
+    riderNormalSignin,
+    riderKakaoRegister,
+    riderGoogleRegister
+}

--- a/utils/auth.js
+++ b/utils/auth.js
@@ -1,0 +1,64 @@
+const jwt = require('jsonwebtoken');
+const userDao = require('../models/userDao');
+
+const userLoginRequired = async(req, res, next) => {
+
+    const { JWT_SECRET } = process.env;
+    const accessToken = req.headers.authorization;
+
+    if(!accessToken) {
+        const error = new Error('NEED_ACCESS_TOKEN');
+        error.statusCode = 401;
+
+        return res.status(error.statusCode).json({ meassage: error.message });   
+    }
+
+    const decoded = jwt.verify(accessToken, JWT_SECRET);
+
+
+    const user = await userDao.getUserById(decoded['userId']);
+
+    if (!user) {
+        const error = new Error('USER_DOES_NOT_EXIST');
+        error.statusCode = 404;
+
+        return res.status(error.statusCode).json({ meassage: error.message });  
+    }
+
+    req.user = user;
+
+    next();
+};
+
+const adminLoginRequired = async(req, res, next) => {
+
+    const { JWT_SECRET } = process.env;
+    const accessToken = req.headers.authorization;
+
+    if(!accessToken) {
+        const error = new Error('NEED_ACCESS_TOKEN');
+        error.statusCode = 401;
+
+        return res.status(error.statusCode).json({ meassage: error.message });   
+    }
+
+    const decoded = jwt.verify(accessToken, JWT_SECRET);
+
+    const admin = await adminDao.getAdminByAdminId(decoded['adminId']);
+
+    if (!admin) {
+        const error = new Error('ADMIN_DOES_NOT_EXIST');
+        error.statusCode = 404;
+
+        return res.status(error.statusCode).json({ meassage: error.message });  
+    }
+
+    req.admin = admin;
+
+    next();
+};
+
+module.exports = {
+    userLoginRequired,
+    adminLoginRequired
+}


### PR DESCRIPTION
**(1) post /sendSMS**
- 인자 3개(userName, userEmail, userPhoneNumber)를 받아서
- userEmail, userPhoneNumber가 DB에 이미 존재하는지 체크, 존재하면 에러메세지 반환
- 신규회원임이 확인되면 전화번호 인증목적에서 userName, userPhoneNumber, randomFourDigit, userEmail 인자 4개 DB 임시 저장
- PhoneNumber 유효성 검사 (010 시작여부, 총 10자리 또는 11자리 숫자가 맞는지)
- Email 유효성 검사 (이메일 형식에 부합하는지)
- 랜덤숫자 4자리 SMS로 발송 / 재전송도 가능

**(2) post /contrastCode**
- 유저가 입력한 인증번호를 DB와 대조
- 인증 실패시 user는 DB에서 삭제됨

**(3) delete**
- [예시] SMS 발송-코드인증 제한시간 초과시
- [예시] 잘못된 인증코드 입력시
- [예시] 회원가입 단계가 완료되지 않은 경우

**(4) post /branchSignup**
- 별따러가자 (지점) 등록에 branchName, branchAddress, branchEmail, branchPassword 4개 인자를,
- 별따러가자 admin 등록을 위해 userName, userEmail, userPhoneNumber 3개 인자를 받음
- Email, PW, PhoneNumber 표현식 부합여부 체크
- 지점명/지점메일주소 DB 중복시 에러메세지 반환
- PW는 솔팅, 키스트레칭 적용한 단방향 암호화 해시 알고리즘인 bcrypt 적용하여 DB에 저장
- 회원가입 완료 버튼 누르면, 트랜잭션 사용하여 createBranch -> updateUser -> createAdmin 진행. 오류발생시 에러메세지와 함께 롤백
- 특이점: 지점 등록시 입력한 branch 주소를 좌표로 변환하여 DB에 경위도값 추가 저장
- 홈페이지의 contact 페이지 - 맵에 지점위치를 표시해주는 section을 위함

**(5) post /adminSignin**
- branchEmail, branchPassword 2개 인자를 받음
- Email, PW 표현식 부합여부 체크
- branchEmail로 branch 존재여부 체크
- branchPassword는 DB의 PW 대조
- PW 일치하면 별따러가자 adminId 암호화된 JWT accessToken 반환하며 로그인 성공

**(6) post /clientSignup**
- client 등록에 companyName, companyRegistrationNumber, companyEmail, companyPassword 4개 인자를,
- users 테이블 등록(client_admin 담당자 등록)에 userName, userEmail, userPhoneNumber 3개 인자를 받음
- Email, PW, PhoneNumber 표현식 부합여부 체크
- 회사명/사업자등록번호/메일주소 DB 중복시 에러메세지 반환
- PW는 솔팅, 키스트레칭 적용한 단방향 암호화 해시 알고리즘인 bcrypt 적용하여 DB에 저장
- 회원가입 완료 버튼 누르면, 트랜잭션 사용하여 createClient > 타 client 소속 rider 또는 client_admin 여부 검사 > updateUser 진행. 오류발생시 에러메세지와 함께 롤백
- updateUser란 해당 유저, 담당자의 소속사업장(client_id) 기재, client 사업장 관리자 권한(client_admin=1) 부여를 의미함

**(7) post /clientSignin**
companyEmail, companyPassword 2개 인자를 받음
Email, PW 표현식 부합여부 체크
companyEmail로 client 존재여부 체크
companyPassword는 DB의 PW 대조
PW 일치하면 고객사 담당자 userId 암호화된 JWT accessToken 반환하며 로그인 성공

**(8) post /riderNormalSignup**
- 소속 사업장 확인을 위해 companyRegistrationNumber를 받음
- users/rider 등록을 위해 userName, userEmail, userPassword, userPhoneNumber 4개 인자를 받음
- Email, PW, PhoneNumber 표현식 부합여부 체크
- 사업자등록번호 존재하지 않을시 에러메세지 반환
- PW는 솔팅, 키스트레칭 적용한 단방향 암호화 해시 알고리즘인 bcrypt 적용하여 DB에 저장
- 회원가입 완료 버튼 누르면, 트랜잭션 사용하여 client admin으로 등록내역 있는지 확인. client_admin은 개인로그인 불가 > updateUser > createRider. 오류발생시 에러메세지와 함께 롤백
- updateUser란 해당 라이더의 소속사업장(client_id) 기재, password 등록을 의미함

**(9) post /riderNormalSignin**
- userEmail, userPassword 2개 인자를 받음
- Email, PW 표현식 부합여부 체크
- userEmail로 client 존재여부 체크
- userPassword는 DB의 PW 대조
- PW 일치하면 라이더의 userId 암호화된 JWT accessToken 반환하며 로그인 성공

**(10) post /riderKakaoSignup**
- FE로부터 카카오 authorizationCode를 받음
- 카카오 서버에 accessToken 요청 > userInfo 요청
- kakaoId로 유저가 DB에 존재하는지 확인. 이미 존재한다면 에러 메세지 반환
- 신규유저라면 사업자등록번호가 DB에 이미 존재하는지, client admin이 아닌 것이 맞는지 확인 후 riderInfo DB에 저장
- 생성된 riderId 반환

**(11) post /riderKakaoSignin**
- FE로부터 카카오 authorizationCode를 받음
- 카카오 서버에 accessToken 요청 > userInfo 요청
- kakaoId로 유저가 DB에 존재하는지 확인. 존재한다면 userId 암호화된 JWT accessToken 반환

**(12) post /riderGoogleSignup**
- FE로부터 googleAccessToken을 받음
- 구글 서버에 userInfo 요청
- googleId로 유저가 DB에 존재하는지 확인. 이미 존재한다면 에러 메세지 반환
- 신규유저라면 사업자등록번호가 DB에 이미 존재하는지, client admin이 아닌 것이 맞는지 확인 후 riderInfo DB에 저장
- 생성된 riderId 반환

**(13) post /riderGoogleSignin**
- FE로부터 googleAccessToken을 받음
- 구글 서버에 userInfo 요청
- googleId로 유저가 DB에 존재하는지 확인. 존재한다면 userId 암호화된 JWT accessToken 반환

--------------------------------------

**[엔드포인트 14, 15 배경]** 프론트 인력/시간부족으로 소셜로그인 레이아웃이 '회원가입'에는 생성되지 못함 : '로그인'에서만 소셜로그인 사용 가능한 상태. 실제로는 /riderKakaoSignup, /riderKakaoSignin 엔드포인트를 사용해야 함.
**[엔드포인트 14, 15 단점]** 사업자등록번호를 확인할 수 없어 해당 라이더의 소속 사업장을 확인할 수 없고, userPhoneNumber을 확인할 수 없어 난수생성하여 임의 저장, 각 소셜로그인마다 제공하는 이메일이 다르므로 한 명의 라이더당 user 테이블에 3개의 행(일반, 카카오, 구글)이 발생할 수 있음

**(14) post /riderKakaoRegister (임시 엔드포인트)**
- FE로부터 카카오 authorizationCode를 받음
- 카카오 서버에 accessToken 요청 > userInfo 요청
- kakaoId로 유저가 DB에 존재하는지 확인
- 유저가 이미 존재하면 userId 암호화된 JWT accessToken 반환
- 신규유저라면 userInfo DB에 저장 후 해당 userId로 accessToken 반환

**(15) post /riderGoogleRegister (임시 엔드포인트)**
- FE로부터 googleAccessToken을 받음
- googleId로 유저가 DB에 존재하는지 확인
- 유저가 이미 존재하면 userId 암호화된 JWT accessToken 반환
- 신규유저라면 구글에 userInfo 요청하여 DB에 저장 후 해당 userId 암호화된 JWT accessToken 반환